### PR TITLE
Update PKGBUILD for meson

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,31 +23,17 @@ pkgver() {
 }
 
 prepare() {
-  cd $pkgname
-  NOCONFIGURE=1 ./autogen.sh
+  arch-meson "$pkgname" "$pkgname/build"
 }
 
 build() {
-  cd $pkgname
-  ./configure --prefix=/usr --libexecdir=/usr/lib --sysconfdir=/etc \
-    --enable-vala --enable-applet
-  make
+  meson compile -C "$pkgname/build"
 }
 
 check () {
-  cd $pkgname
-  make check
+  meson test -C "$pkgname/build"
 }
 
 package() {
-  cd $pkgname
-  make DESTDIR="$pkgdir" install
-
-  install -Dm644 data/completions/gpaste-client \
-    "$pkgdir/usr/share/bash-completion/completions/gpaste-client"
-  install -Dm644 data/completions/_gpaste-client \
-    "$pkgdir/usr/share/zsh/site-functions/_gpaste-client"
-
-  # Don't autostart the applet, ever
-  rm "$pkgdir/etc/xdg/autostart/org.gnome.GPaste.Applet.desktop"
+  meson install --destdir "$pkgdir" -C "$pkgname/build"
 }


### PR DESCRIPTION
gpaste switched to meson in 2019.

not sure if the build path should be under $pkgname or somewhere next to it. autostart is not installed anymore, bash and zsh completion files are installed to the right place. everything seems to work fine for me with these changes.